### PR TITLE
Centralize resume data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { siteMetadata } from "@/data/resume";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -12,19 +13,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "Minh Le - Software Engineer",
-  description: "Computer Science student at NJIT with experience in full-stack development, machine learning, and high-performance computing. Passionate about building scalable solutions and innovative technologies.",
-  keywords: ["Minh Le", "Software Engineer", "Computer Science", "NJIT", "Full Stack Developer", "React", "Node.js", "Python", "TypeScript"],
-  authors: [{ name: "Minh Le" }],
-  creator: "Minh Le",
-  openGraph: {
-    title: "Minh Le - Software Engineer",
-    description: "Computer Science student at NJIT with experience in full-stack development, machine learning, and high-performance computing.",
-    type: "website",
-    locale: "en_US",
-  },
-};
+export const metadata: Metadata = siteMetadata;
 
 export default function RootLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { resumeData } from '@/data/resume';
 
 // Navigation Component
 const Navigation = () => {
@@ -219,9 +220,11 @@ export default function Home() {
     setTimeout(() => setToastMessage(null), 3000);
   };
 
-  const handleEmailClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+  const handleEmailClick = (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => {
     e.preventDefault();
-    const email = 'minhqle279@gmail.com';
+    const email = resumeData.personal.email;
     navigator.clipboard.writeText(email);
     showToast(`Email copied to clipboard: ${email}`);
   };
@@ -235,28 +238,27 @@ export default function Home() {
         <div className="max-w-4xl mx-auto text-center">
           <div className="mb-8">
             <h1 className="text-4xl sm:text-6xl font-bold text-foreground mb-6">
-              Hi, I&apos;m <span className="text-primary">Minh Le</span>
+              Hi, I&apos;m{' '}
+              <span className="text-primary">{resumeData.personal.name}</span>
             </h1>
             <p className="text-xl sm:text-2xl text-muted-foreground mb-8">
-              Computer Science Student & Software Engineer
+              {resumeData.personal.tagline}
             </p>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-              Passionate about building scalable solutions and innovative technologies. 
-              Currently pursuing BSc. Computer Science at NJIT with experience in 
-              full-stack development, machine learning, and high-performance computing.
+              {resumeData.personal.bio}
             </p>
           </div>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <a
-              href="mailto:minhqle279@gmail.com"
+              href={`mailto:${resumeData.personal.email}`}
               onClick={handleEmailClick}
               className="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-accent transition-colors"
             >
               Get In Touch
             </a>
             <a
-              href="https://linkedin.com/in/minhle27"
+              href={resumeData.personal.linkedIn}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-muted transition-colors"
@@ -266,19 +268,33 @@ export default function Home() {
           </div>
           
           <div className="flex justify-center space-x-6 text-muted-foreground">
-            <a href="mailto:minhqle279@gmail.com" onClick={handleEmailClick} className="hover:text-primary transition-colors">
+            <a
+              href={`mailto:${resumeData.personal.email}`}
+              onClick={handleEmailClick}
+              className="hover:text-primary transition-colors"
+            >
               <span className="sr-only">Email</span>
               <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 12.713l-11.985-9.713h23.97l-11.985 9.713zm0 2.574l-12-9.725v15.438h24v-15.438l-12 9.725z"/>
               </svg>
             </a>
-            <a href="https://linkedin.com/in/minhle27" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">
+            <a
+              href={resumeData.personal.linkedIn}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary transition-colors"
+            >
               <span className="sr-only">LinkedIn</span>
               <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
               </svg>
             </a>
-            <a href="https://github.com/minhle27" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">
+            <a
+              href={resumeData.personal.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary transition-colors"
+            >
               <span className="sr-only">GitHub</span>
               <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 1C5.923 1 1 5.923 1 12c0 4.867 3.149 8.979 7.521 10.436.55.096.756-.233.756-.522 0-.262-.013-1.128-.013-2.049-2.764.509-3.479-.674-3.699-1.292-.124-.317-.66-1.293-1.127-1.554-.385-.207-.936-.715-.014-.729.866-.014 1.485.797 1.691 1.128.99 1.663 2.571 1.196 3.204.907.096-.715.385-1.196.701-1.471-2.448-.275-5.005-1.224-5.005-5.432 0-1.196.426-2.186 1.128-2.956-.111-.275-.496-1.402.11-2.915 0 0 .921-.288 3.024 1.128a10.193 10.193 0 0 1 2.75-.371c.936 0 1.871.123 2.75.371 2.104-1.43 3.025-1.128 3.025-1.128.605 1.513.221 2.64.111 2.915.701.77 1.127 1.747 1.127 2.956 0 4.222-2.571 5.157-5.019 5.432.399.344.743 1.004.743 2.035 0 1.471-.014 2.654-.014 3.025 0 .289.206.632.756.522C19.851 20.979 23 16.854 23 12c0-6.077-4.922-11-11-11Z"/>
@@ -290,34 +306,32 @@ export default function Home() {
 
       {/* Education Section */}
       <section id="education" className="py-20 px-4 sm:px-6 lg:px-8 bg-muted">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-12">Education</h2>
-          <div className="bg-background rounded-lg p-8 shadow-sm">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-              <div>
-                <h3 className="text-2xl font-semibold text-foreground">New Jersey Institute of Technology</h3>
-                <p className="text-primary font-medium">BSc. Computer Science</p>
-                <p className="text-muted-foreground">GPA: 3.85</p>
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-center mb-12">Education</h2>
+            <div className="bg-background rounded-lg p-8 shadow-sm">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
+                <div>
+                  <h3 className="text-2xl font-semibold text-foreground">
+                    {resumeData.education.institution}
+                  </h3>
+                  <p className="text-primary font-medium">{resumeData.education.degree}</p>
+                  <p className="text-muted-foreground">GPA: {resumeData.education.gpa}</p>
+                </div>
+                <div className="text-right mt-4 sm:mt-0">
+                  <p className="text-muted-foreground">{resumeData.education.location}</p>
+                  <p className="text-muted-foreground">{resumeData.education.graduation}</p>
+                </div>
               </div>
-              <div className="text-right mt-4 sm:mt-0">
-                <p className="text-muted-foreground">Newark, NJ</p>
-                <p className="text-muted-foreground">Expected Dec 2026</p>
-              </div>
-            </div>
-            <div className="mt-6">
-              <h4 className="font-semibold mb-3">Relevant Coursework:</h4>
-              <div className="flex flex-wrap gap-2">
-                {[
-                  'Data Structures and Algorithms', 'Object-oriented Programming', 'Computer System',
-                  'Database System', 'Computer Network', 'Operating System', 'Programming Languages',
-                  'Machine Learning', 'Parallel Computing'
-                ].map((course) => (
-                  <SkillBadge key={course} skill={course} />
-                ))}
+              <div className="mt-6">
+                <h4 className="font-semibold mb-3">Relevant Coursework:</h4>
+                <div className="flex flex-wrap gap-2">
+                  {resumeData.education.coursework.map((course) => (
+                    <SkillBadge key={course} skill={course} />
+                  ))}
+                </div>
               </div>
             </div>
           </div>
-        </div>
       </section>
 
       {/* Technical Skills Section */}
@@ -328,7 +342,7 @@ export default function Home() {
             <div>
               <h3 className="text-xl font-semibold mb-4">Languages</h3>
               <div className="flex flex-wrap gap-2">
-                {['C/C++', 'Python', 'Java', 'CUDA', 'SQL', 'JavaScript', 'TypeScript', 'HTML/CSS', 'PHP'].map((skill) => (
+                {resumeData.skills.languages.map((skill) => (
                   <SkillBadge key={skill} skill={skill} />
                 ))}
               </div>
@@ -336,7 +350,7 @@ export default function Home() {
             <div>
               <h3 className="text-xl font-semibold mb-4">Technologies</h3>
               <div className="flex flex-wrap gap-2">
-                {['React', 'Node.js', 'Express', 'Nest.JS', 'MongoDB', 'Django', 'Flask', 'GraphQL', 'Pandas', 'Matplotlib', 'LangChain'].map((skill) => (
+                {resumeData.skills.technologies.map((skill) => (
                   <SkillBadge key={skill} skill={skill} />
                 ))}
               </div>
@@ -350,36 +364,16 @@ export default function Home() {
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-12">Experience</h2>
           <div className="space-y-8">
-            <ExperienceCard
-              title="Software Engineer Intern"
-              company="CoderPush"
-              period="June 2024 – Aug. 2024"
-              achievements={[
-                "Developed backend API services for gamification features using PostgreSQL and NestJS to process 20+ event types, increasing user engagement by 30%",
-                "Built an interactive admin dashboard using Recharts to visualize 8 critical metrics, resulting in a 20% improvement in stakeholder operational insights",
-                "Enhanced the admin Content Management System (CMS) by leveraging AdminJS and implementing custom React components",
-                "Developed an internal resume processing tool with a custom parsing module that achieved 85% accuracy in extracting resume attributes, reducing HR processing time by 50%"
-              ]}
-            />
-            <ExperienceCard
-              title="Research Assistant"
-              company="NJIT Dasgupta's Data Visualization lab"
-              period="Jan. 2024 – May 2024"
-              achievements={[
-                "Developed a conversational interface with a Flask backend and React frontend, allowing users to interact with algorithmic rankers and access ML model decision explanations",
-                "Improved model transparency through development of interactive data visualizations using NL4DV",
-                "Leveraged Pandas to preprocess admissions dataset for testing interface efficacy and applicability in real-world scenarios"
-              ]}
-            />
-            <ExperienceCard
-              title="Teaching Assistant"
-              company="NJIT CS113"
-              period="Jan. 2024 – May 2024"
-              achievements={[
-                "Assisted 80+ students on Object-Oriented Programming concepts in Java through hands-on lab sessions",
-                "Held weekly office hours to offer additional academic support, clarify complex topics, and foster student success"
-              ]}
-            />
+            {resumeData.experiences.map((exp) => (
+              <ExperienceCard
+                key={exp.title}
+                title={exp.title}
+                company={exp.company}
+                period={exp.period}
+                achievements={exp.achievements}
+              />
+            ))}
+
           </div>
         </div>
       </section>
@@ -389,53 +383,17 @@ export default function Home() {
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-12">Projects</h2>
           <div className="grid gap-8 lg:grid-cols-2">
-            <ProjectCard
-              title="Image Segmentation Engine"
-              technologies="C++, CUDA, OpenMPI, OpenCV, CMake, Python"
-              description="High-performance image segmentation system using K-means clustering"
-              achievements={[
-                "Developed a K-means clustering module for image segmentation, partitioning pixels into coherent color regions",
-                "Scaled the pipeline across two Linux nodes with MPI and accelerated core clustering routines on NVIDIA GPUs via CUDA",
-                "Achieved a 23x reduction in end-to-end runtime on large image datasets",
-                "Utilized Python to create visualizations comparing performance metrics across four implementations"
-              ]}
-              githubLink="https://github.com/minhle27"
-            />
-            <ProjectCard
-              title="NJIT Jobs"
-              technologies="React, Redux Toolkit, Express, MongoDB, TypeScript, TailwindCSS, Socket.io"
-              description="User-friendly platform for on-campus job search and application management"
-              achievements={[
-                "Led a team of 3 to build a platform that streamlined the on-campus job search process for students",
-                "Leveraged best practices in RTK Query to implement robust state management layer",
-                "Significantly enhanced API data handling and optimized overall client side rendering performance",
-                "Designed and implemented a real-time messaging system to facilitate direct employer-student communication"
-              ]}
-              githubLink="https://github.com/minhle27"
-            />
-            <ProjectCard
-              title="GitLet"
-              technologies="Java, Makefile"
-              description="Version-control system implementation with basic Git functionality"
-              achievements={[
-                "Implemented a version-control system for related collections of files with basic features such as committing, restoring files, viewing commit history",
-                "Maintained branches and merging changes functionality",
-                "Created efficient internal structures to effectively handle file contents and metadata",
-                "Utilized carefully selected data structures and algorithms to maximize performance, with 100% test coverage"
-              ]}
-              githubLink="https://github.com/minhle27"
-            />
-            <ProjectCard
-              title="MyNJIT Prof"
-              technologies="JavaScript, GraphQL, webpack, Tailwind CSS"
-              description="Chrome extension for NJIT students to access professor ratings"
-              achievements={[
-                "Developed a custom Chrome extension specifically designed for NJIT students",
-                "Enabled convenient access to professor rating information from ratemyprofessor.com directly on the school's registration webpage",
-                "Increased course selecting efficiency for 5000+ students by 30%"
-              ]}
-              githubLink="https://github.com/minhle27"
-            />
+            {resumeData.projects.map((project) => (
+              <ProjectCard
+                key={project.title}
+                title={project.title}
+                technologies={project.technologies}
+                description={project.description}
+                achievements={project.achievements}
+                githubLink={project.githubLink}
+              />
+            ))}
+
           </div>
         </div>
       </section>
@@ -445,15 +403,14 @@ export default function Home() {
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-12">Awards</h2>
           <div className="space-y-6">
-            <div className="bg-background rounded-lg p-6 shadow-sm">
-              <h3 className="text-xl font-semibold text-foreground mb-2">Vietnam Southern Open Mathematical Competition 2021</h3>
-              <p className="text-primary font-medium">Gold Medalist</p>
-            </div>
-            <div className="bg-background rounded-lg p-6 shadow-sm">
-              <h3 className="text-xl font-semibold text-foreground mb-2">Ho Chi Minh City excellent students in Mathematics 2019</h3>
-              <p className="text-primary font-medium">First Prize</p>
-            </div>
+            {resumeData.awards.map((award) => (
+              <div className="bg-background rounded-lg p-6 shadow-sm" key={award.title}>
+                <h3 className="text-xl font-semibold text-foreground mb-2">{award.title}</h3>
+                <p className="text-primary font-medium">{award.subtitle}</p>
+              </div>
+            ))}
           </div>
+
         </div>
       </section>
 
@@ -467,7 +424,7 @@ export default function Home() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <a
-              href="mailto:minhqle279@gmail.com"
+              href={`mailto:${resumeData.personal.email}`}
               onClick={handleEmailClick}
               className="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:bg-accent transition-colors"
             >
@@ -477,7 +434,7 @@ export default function Home() {
               Email Me
             </a>
             <a
-              href="https://linkedin.com/in/minhle27"
+              href={resumeData.personal.linkedIn}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-muted transition-colors"
@@ -492,15 +449,15 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
             <div>
               <h3 className="font-semibold mb-2">Email</h3>
-              <p className="text-muted-foreground">minhqle279@gmail.com</p>
+              <p className="text-muted-foreground">{resumeData.personal.email}</p>
             </div>
             <div>
               <h3 className="font-semibold mb-2">Phone</h3>
-              <p className="text-muted-foreground">201-936-3032</p>
+              <p className="text-muted-foreground">{resumeData.personal.phone}</p>
             </div>
             <div>
               <h3 className="font-semibold mb-2">Location</h3>
-              <p className="text-muted-foreground">Newark, NJ</p>
+              <p className="text-muted-foreground">{resumeData.personal.location}</p>
             </div>
           </div>
         </div>
@@ -510,7 +467,7 @@ export default function Home() {
       <footer className="py-8 px-4 sm:px-6 lg:px-8 bg-muted border-t border-border">
         <div className="max-w-4xl mx-auto text-center">
           <p className="text-muted-foreground">
-            © 2024 Minh Le. Built with Next.js and Tailwind CSS.
+            © {new Date().getFullYear()} {resumeData.personal.name}. Built with Next.js and Tailwind CSS.
           </p>
         </div>
       </footer>

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -124,7 +124,9 @@ export const resumeData = {
   ],
 };
 
-export const siteMetadata = {
+import type { Metadata } from "next";
+
+export const siteMetadata: Metadata = {
   title: `${resumeData.personal.name} - Software Engineer`,
   description: resumeData.personal.bio,
   keywords: [
@@ -146,4 +148,4 @@ export const siteMetadata = {
     type: 'website',
     locale: 'en_US',
   },
-} as const;
+};

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -1,0 +1,149 @@
+export const resumeData = {
+  personal: {
+    name: 'Minh Le',
+    tagline: 'Computer Science Student & Software Engineer',
+    bio: 'Passionate about building scalable solutions and innovative technologies. Currently pursuing BSc. Computer Science at NJIT with experience in full-stack development, machine learning, and high-performance computing.',
+    email: 'minhqle279@gmail.com',
+    phone: '201-936-3032',
+    location: 'Newark, NJ',
+    linkedIn: 'https://linkedin.com/in/minhle27',
+    github: 'https://github.com/minhle27',
+  },
+  education: {
+    institution: 'New Jersey Institute of Technology',
+    degree: 'BSc. Computer Science',
+    gpa: '3.85',
+    location: 'Newark, NJ',
+    graduation: 'Expected Dec 2026',
+    coursework: [
+      'Data Structures and Algorithms',
+      'Object-oriented Programming',
+      'Computer System',
+      'Database System',
+      'Computer Network',
+      'Operating System',
+      'Programming Languages',
+      'Machine Learning',
+      'Parallel Computing',
+    ],
+  },
+  skills: {
+    languages: ['C/C++', 'Python', 'Java', 'CUDA', 'SQL', 'JavaScript', 'TypeScript', 'HTML/CSS', 'PHP'],
+    technologies: ['React', 'Node.js', 'Express', 'Nest.JS', 'MongoDB', 'Django', 'Flask', 'GraphQL', 'Pandas', 'Matplotlib', 'LangChain'],
+  },
+  experiences: [
+    {
+      title: 'Software Engineer Intern',
+      company: 'CoderPush',
+      period: 'June 2024 – Aug. 2024',
+      achievements: [
+        'Developed backend API services for gamification features using PostgreSQL and NestJS to process 20+ event types, increasing user engagement by 30%',
+        'Built an interactive admin dashboard using Recharts to visualize 8 critical metrics, resulting in a 20% improvement in stakeholder operational insights',
+        'Enhanced the admin Content Management System (CMS) by leveraging AdminJS and implementing custom React components',
+        'Developed an internal resume processing tool with a custom parsing module that achieved 85% accuracy in extracting resume attributes, reducing HR processing time by 50%',
+      ],
+    },
+    {
+      title: 'Research Assistant',
+      company: "NJIT Dasgupta's Data Visualization lab",
+      period: 'Jan. 2024 – May 2024',
+      achievements: [
+        'Developed a conversational interface with a Flask backend and React frontend, allowing users to interact with algorithmic rankers and access ML model decision explanations',
+        'Improved model transparency through development of interactive data visualizations using NL4DV',
+        'Leveraged Pandas to preprocess admissions dataset for testing interface efficacy and applicability in real-world scenarios',
+      ],
+    },
+    {
+      title: 'Teaching Assistant',
+      company: 'NJIT CS113',
+      period: 'Jan. 2024 – May 2024',
+      achievements: [
+        'Assisted 80+ students on Object-Oriented Programming concepts in Java through hands-on lab sessions',
+        'Held weekly office hours to offer additional academic support, clarify complex topics, and foster student success',
+      ],
+    },
+  ],
+  projects: [
+    {
+      title: 'Image Segmentation Engine',
+      technologies: 'C++, CUDA, OpenMPI, OpenCV, CMake, Python',
+      description: 'High-performance image segmentation system using K-means clustering',
+      achievements: [
+        'Developed a K-means clustering module for image segmentation, partitioning pixels into coherent color regions',
+        'Scaled the pipeline across two Linux nodes with MPI and accelerated core clustering routines on NVIDIA GPUs via CUDA',
+        'Achieved a 23x reduction in end-to-end runtime on large image datasets',
+        'Utilized Python to create visualizations comparing performance metrics across four implementations',
+      ],
+      githubLink: 'https://github.com/minhle27',
+    },
+    {
+      title: 'NJIT Jobs',
+      technologies: 'React, Redux Toolkit, Express, MongoDB, TypeScript, TailwindCSS, Socket.io',
+      description: 'User-friendly platform for on-campus job search and application management',
+      achievements: [
+        'Led a team of 3 to build a platform that streamlined the on-campus job search process for students',
+        'Leveraged best practices in RTK Query to implement robust state management layer',
+        'Significantly enhanced API data handling and optimized overall client side rendering performance',
+        'Designed and implemented a real-time messaging system to facilitate direct employer-student communication',
+      ],
+      githubLink: 'https://github.com/minhle27',
+    },
+    {
+      title: 'GitLet',
+      technologies: 'Java, Makefile',
+      description: 'Version-control system implementation with basic Git functionality',
+      achievements: [
+        'Implemented a version-control system for related collections of files with basic features such as committing, restoring files, viewing commit history',
+        'Maintained branches and merging changes functionality',
+        'Created efficient internal structures to effectively handle file contents and metadata',
+        'Utilized carefully selected data structures and algorithms to maximize performance, with 100% test coverage',
+      ],
+      githubLink: 'https://github.com/minhle27',
+    },
+    {
+      title: 'MyNJIT Prof',
+      technologies: 'JavaScript, GraphQL, webpack, Tailwind CSS',
+      description: 'Chrome extension for NJIT students to access professor ratings',
+      achievements: [
+        'Developed a custom Chrome extension specifically designed for NJIT students',
+        "Enabled convenient access to professor rating information from ratemyprofessor.com directly on the school's registration webpage",
+        'Increased course selecting efficiency for 5000+ students by 30%',
+      ],
+      githubLink: 'https://github.com/minhle27',
+    },
+  ],
+  awards: [
+    {
+      title: 'Vietnam Southern Open Mathematical Competition 2021',
+      subtitle: 'Gold Medalist',
+    },
+    {
+      title: 'Ho Chi Minh City excellent students in Mathematics 2019',
+      subtitle: 'First Prize',
+    },
+  ],
+};
+
+export const siteMetadata = {
+  title: `${resumeData.personal.name} - Software Engineer`,
+  description: resumeData.personal.bio,
+  keywords: [
+    resumeData.personal.name,
+    'Software Engineer',
+    'Computer Science',
+    'NJIT',
+    'Full Stack Developer',
+    'React',
+    'Node.js',
+    'Python',
+    'TypeScript',
+  ],
+  authors: [{ name: resumeData.personal.name }],
+  creator: resumeData.personal.name,
+  openGraph: {
+    title: `${resumeData.personal.name} - Software Engineer`,
+    description: resumeData.personal.bio,
+    type: 'website',
+    locale: 'en_US',
+  },
+} as const;


### PR DESCRIPTION
## Summary
- pull personal, education, skill, experience, project and award info into `resume.ts`
- use the centralized data in page layout and hero page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614412914c832bb5d435966888f19f